### PR TITLE
Jkw send message setup

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -9,3 +9,20 @@ export const fetchItems = async () => {
         throw response
     }
 }
+
+export const sendMessage = async (body) => {
+    console.log(body)
+    const response = await fetch(`${rootUrl}/api/v1/messages`, {
+        'method': 'POST',
+        'headers': {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(body)
+    })
+    if(response.ok) {
+        const res = response.json()
+        return res
+    } else {
+        throw response
+    }
+}

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,0 +1,11 @@
+const rootUrl = 'http://localhost:1337'
+
+const fetchItems = async () => {
+    const response = await fetch(`${rootUrl}/api/v1/items`)
+    if(response.ok) {
+        const favorites = response.json()
+        return favorites
+    } else {
+        throw response
+    }
+}

--- a/src/components/Item/Item.js
+++ b/src/components/Item/Item.js
@@ -6,6 +6,7 @@ const Item = ({ id, name, imageUrl }) => {
         <div className='item-card' id={id}>
             <img className='item-image' src={imageUrl} alt={name} />
             <h1 className='item-name'>{name}</h1>
+            <button name={name} onClick={handleClick}>Send Text</button>
         </div>
     )
 }

--- a/src/components/Item/Item.js
+++ b/src/components/Item/Item.js
@@ -1,7 +1,19 @@
 import React from 'react';
 import './Item.css'
+import { sendMessage } from '../../apiCalls'
 
 const Item = ({ id, name, imageUrl }) => {
+    const handleClick = (event) => {
+        event.preventDefault();
+        const itemName = name;
+        const phoneNumber = '+15555555555';
+        const body = {
+            to: phoneNumber,
+            body: itemName
+        }
+        sendMessage(body)
+    }
+
     return(
         <div className='item-card' id={id}>
             <img className='item-image' src={imageUrl} alt={name} />

--- a/src/components/Item/Item.test.js
+++ b/src/components/Item/Item.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import Item from './Item'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { sendMessage } from '../../apiCalls'
+jest.mock('../../apiCalls')
 
 describe('Item', () => {
     it('Should render the correct content on display', () => {
@@ -10,8 +12,23 @@ describe('Item', () => {
 
         const itemName = screen.getByRole('heading', { name: 'Candle' })
         const image = screen.getByAltText('Candle')
+        const button = screen.getByRole('button', { name: 'Send Text' })
 
         expect(itemName).toBeInTheDocument();
         expect(image).toBeInTheDocument();
+        expect(button).toBeInTheDocument();
+    })
+
+    it('Should make a network request when a item is clicked on', () => {
+        render(<Item id={999} name='Candle' imageUrl='www.image.candle.png' />)
+
+        const button = screen.getByRole('button', { name: 'Send Text' })
+        fireEvent.click(button)
+
+        expect(sendMessage).toBeCalledTimes(1)
+        expect(sendMessage).toBeCalledWith({
+            "to": "+19102625254",
+            "body": "Candle"
+        })
     })
 })

--- a/src/components/SmellKit/SmellKit.js
+++ b/src/components/SmellKit/SmellKit.js
@@ -21,14 +21,13 @@ class SmellKit extends Component {
             this.setState({ error: error })
         }
     }
-
     createItemCards = () => {
         const items = this.state.items;
         const itemIds = Object.keys(this.state.items);
         return itemIds.map(id => {
             const name = items[id].name;
             const imageUrl = items[id].image;
-            return <Item key={id} id={id} name={items[id].name} imageUrl={items[id].image} />
+            return <Item key={id} id={id} name={name} imageUrl={imageUrl} />
         })
     }
     


### PR DESCRIPTION
#### What's this PR do?
- Adds a `sendMessage` fetch method in apiCalls
- Adds test code & implementation code for a `Send Text` button on each card. When both the FE and BE servers are running, users can click this button to trigger a text message.
#### Where should the reviewer start?
- Check out `Item.test` and `Item` to get a sense for this functionality! Then check out `sendMessage` in apiCalls to see how this is talking to my BE server.
#### How should this be manually tested?
- Run `npm start` to launch site; get express server running with `nodemon server.js`
#### Any background context you want to provide?
- My workflow here got a little out of order after pushing some info to GitHub that I didn't want there! As such, my apiCall is added a little later in the commit flow than it was written.
#### What are the relevant tickets?
- Close #18 
#### Screenshots (if appropriate)
- n/a
#### Questions:
- How am I going to take text responses back from the user and turn that into data on the screen?
